### PR TITLE
Fix unexpected update of jumplist

### DIFF
--- a/autoload/ikaring.vim
+++ b/autoload/ikaring.vim
@@ -34,7 +34,7 @@ function! ikaring#_read(path) abort
   endtry
   setlocal modifiable noreadonly
   silent 1 put =lines
-  silent 1 delete _
+  keepjumps silent 1 delete _
   if has_key(view, 'init')
     call view.init()
   endif


### PR DESCRIPTION
Problem:
  After opening a view, CTRL-O jumps to the end of buffer instead of
  older position. `1 delete _` updates jumplist.

Solution:
  Prepend :keepjumps to `silent 1 delete _`
